### PR TITLE
Support for service syntaxis and ability to generate IServiceSupporter and ServiceRpcNames

### DIFF
--- a/CodeGenerator/CodeGenerator.csproj
+++ b/CodeGenerator/CodeGenerator.csproj
@@ -29,7 +29,7 @@
     <OutputPath>bin\Debug</OutputPath>
     <DefineConstants>DEBUG</DefineConstants>
     <ConsolePause>False</ConsolePause>
-    <Commandlineparameters>--fix-nameclash ../../../TestProgram/ProtoSpec/LocalFeatures.proto --no-generate-imported --output ../../../TestProgram/Generated/GeneratedLocal.cs --ctor --utc --skip-default</Commandlineparameters>
+    <Commandlineparameters>--fix-nameclash ../../../../TestProgram/ProtoSpec/LocalFeatures.proto --no-generated-imports --generate-services --output ../../../../TestProgram/Generated/GeneratedLocal.cs --ctor --utc --skip-default</Commandlineparameters>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <Optimize>False</Optimize>

--- a/CodeGenerator/CodeGenerator/MessageCode.cs
+++ b/CodeGenerator/CodeGenerator/MessageCode.cs
@@ -142,6 +142,13 @@ namespace SilentOrbit.ProtocolBuffers
             cw.WriteLine();
         }
 
+        internal static void GenerateService(ProtoService s, CodeWriter cw)
+        {
+            ServiceWriter.GenerateRpcNames(s, cw);
+            cw.WriteLine();
+            ServiceWriter.GenerateInterface(s, cw);
+        }
+
         /// <summary>
         /// Generates the properties.
         /// </summary>

--- a/CodeGenerator/CodeGenerator/ProtoCode.cs
+++ b/CodeGenerator/CodeGenerator/ProtoCode.cs
@@ -79,6 +79,22 @@ then write the code and the changes in a separate file.");
                     cw.WriteLine();
                 }
 
+                if (options.GenerateServices)
+                {
+                    foreach (ProtoService s in file.Services.Values)
+                    {
+                        if (ns != s.CsNamespace)
+                        {
+                            if (ns != null) //First time
+                                cw.EndBracket();
+                            cw.Bracket("namespace " + s.CsNamespace);
+                            ns = s.CsNamespace;
+                        }
+                        MessageCode.GenerateService(s, cw);
+                        cw.WriteLine();
+                    }
+                }
+
                 if (ns != null)
                 {
                     cw.EndBracket();

--- a/CodeGenerator/CodeGenerator/ServiceWriter.cs
+++ b/CodeGenerator/CodeGenerator/ServiceWriter.cs
@@ -1,0 +1,33 @@
+using SilentOrbit.Code;
+
+namespace SilentOrbit.ProtocolBuffers
+{
+    static class ServiceWriter
+    {
+        internal static void GenerateRpcNames(ProtoService s, CodeWriter cw)
+        {
+            cw.Bracket($"public static class {s.CsType}RpcNames");
+
+            foreach (var m in s.Methods.Values)
+            {
+                cw.WriteLine($"public const string {m.ProtoName} = \"{s.CsType}_{m.ProtoName}\";");
+            }
+
+            cw.EndBracket();
+        }
+
+        internal static void GenerateInterface(ProtoService s, CodeWriter cw)
+        {
+            cw.Summary(s.Comments);
+            cw.Bracket($"public interface I{s.CsType}Supporter");
+
+            foreach (var m in s.Methods.Values)
+            {
+                cw.Summary(m.Comments);
+                cw.WriteLine($"{m.ResponseProtoType.FullProtoName} {m.ProtoName}({m.RequestProtoType.FullProtoName} request);");
+            }
+
+            cw.EndBracket();
+        }
+    }
+}

--- a/CodeGenerator/Options.cs
+++ b/CodeGenerator/Options.cs
@@ -92,6 +92,12 @@ namespace SilentOrbit.ProtocolBuffers
         [Option("no-generated-imports", HelpText = "Do not generate files for imported protos.")]
         public bool NoGenerateImported { get; set; }
 
+        /// <summary>
+        /// Don't generate code from imported .proto files.
+        /// </summary>
+        [Option("generate-services", HelpText = "Generate IServiceSupporter and ServiceRpcNames for given service definitions.")]
+        public bool GenerateServices { get; set; }
+
         public static void TryParse(string[] args, Action<Options> onSuccess)
         {
             var result = Parser.Default.ParseArguments<Options>(args)

--- a/CodeGenerator/Properties/launchSettings.json
+++ b/CodeGenerator/Properties/launchSettings.json
@@ -1,0 +1,8 @@
+{
+  "profiles": {
+    "CodeGenerator": {
+      "commandName": "Project",
+      "commandLineArgs": "--fix-nameclash ../../../../TestProgram/ProtoSpec/LocalFeatures.proto --no-generated-imports --generate-services --output ../../../../TestProgram/Generated/GeneratedLocal.cs --ctor --utc --skip-default"
+    }
+  }
+}

--- a/CodeGenerator/Proto/ProtoCollection.cs
+++ b/CodeGenerator/Proto/ProtoCollection.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Text;
 
 namespace SilentOrbit.ProtocolBuffers
 {
@@ -48,13 +49,23 @@ namespace SilentOrbit.ProtocolBuffers
 
         public override string ToString()
         {
-            string t = "ProtoCollection: ";
+            var b = new StringBuilder("ProtoCollection: ");
             foreach (ProtoMessage m in Messages.Values)
             {
-                t += "\n\t" + m;
+                b.Append("\n\t").Append(m);
             }
 
-            return t;
+            foreach (ProtoEnum e in Enums.Values)
+            {
+                b.Append("\n\t").Append(e);
+            }
+
+            foreach (ProtoService s in Services.Values)
+            {
+                b.Append("\n\t").Append(s);
+            }
+
+            return b.ToString();
         }
     }
 }

--- a/CodeGenerator/Proto/ProtoCollection.cs
+++ b/CodeGenerator/Proto/ProtoCollection.cs
@@ -39,6 +39,11 @@ namespace SilentOrbit.ProtocolBuffers
                 Enums.Add(e.ProtoName, e);
                 e.Parent = this;
             }
+            foreach (var s in proto.Services.Values)
+            {
+                Services.Add(s.ProtoName, s);
+                s.Parent = this;
+            }
         }
 
         public override string ToString()

--- a/CodeGenerator/Proto/ProtoEnum.cs
+++ b/CodeGenerator/Proto/ProtoEnum.cs
@@ -27,6 +27,9 @@ namespace SilentOrbit.ProtocolBuffers
             : base(parent, package)
         {
         }
+
+        public override string ToString()
+            => "enum " + FullProtoName;
     }
 
     public class ProtoEnumValue

--- a/CodeGenerator/Proto/ProtoMessage.cs
+++ b/CodeGenerator/Proto/ProtoMessage.cs
@@ -15,6 +15,7 @@ namespace SilentOrbit.ProtocolBuffers
         public Dictionary<int, Field> Fields = new Dictionary<int, Field>();
         public Dictionary<string, ProtoMessage> Messages = new Dictionary<string, ProtoMessage>();
         public Dictionary<string, ProtoEnum> Enums = new Dictionary<string, ProtoEnum>();
+        public Dictionary<string,ProtoService> Services = new Dictionary<string, ProtoService>();
 
         public string SerializerType
         {

--- a/CodeGenerator/Proto/ProtoService.cs
+++ b/CodeGenerator/Proto/ProtoService.cs
@@ -1,0 +1,51 @@
+using System.Collections.Generic;
+
+namespace SilentOrbit.ProtocolBuffers
+{
+    class ProtoService : ProtoType, IComment
+    {
+        public override Wire WireType => Wire.Varint;
+
+        public string Comments { get; set; }
+        public Dictionary<string, RpcMethod> Methods
+            = new Dictionary<string, RpcMethod>();
+
+        public ProtoService(ProtoMessage parent, string package)
+            : base(parent, package)
+        {
+        }
+
+        public override string ToString()
+            => "service " + this.FullProtoName;
+    }
+
+    class RpcMethod : IComment
+    {
+        public string Comments { get; set; }
+
+        /// <summary>
+        /// Method name as read from the .proto file
+        /// </summary>
+        public string ProtoName { get; set; }
+
+        /// <summary>
+        /// Request type as read from the .proto file
+        /// </summary>
+        public string RequestTypeName { get; set; }
+
+        /// <summary>
+        /// Response name read from the .proto file
+        /// </summary>
+        public string ResponseTypeName { get; set; }
+
+        public ProtoType RequestProtoType { get; set; }
+        public ProtoType ResponseProtoType { get; set; }
+        public string CsName { get; internal set; }
+        public readonly SourcePath Source;
+
+        public RpcMethod(TokenReader tr)
+        {
+            Source = new SourcePath(tr);
+        }
+    }
+}

--- a/CodeGenerator/TokenReader.cs
+++ b/CodeGenerator/TokenReader.cs
@@ -7,7 +7,7 @@ namespace SilentOrbit.ProtocolBuffers
     {
         public readonly string Path;
         readonly string whitespace = " \t\r\n";
-        readonly string singletoken = "{}=[];,";
+        readonly string singletoken = "{}=[];,()";
         readonly string text;
 
         public TokenReader(string text, string path)

--- a/TestProgram/Generated/GeneratedLocal.Serializer.cs
+++ b/TestProgram/Generated/GeneratedLocal.Serializer.cs
@@ -49,7 +49,7 @@ namespace Local
         }
 
         /// <summary>Helper: put the buffer into a MemoryStream before deserializing</summary>
-        internal static Local.LocalFeatures Deserialize(byte[] buffer, Local.LocalFeatures instance)
+        internal static global::Local.LocalFeatures Deserialize(byte[] buffer, global::Local.LocalFeatures instance)
         {
             using (var ms = new MemoryStream(buffer))
                 Deserialize(ms, instance);
@@ -57,10 +57,10 @@ namespace Local
         }
 
         /// <summary>Takes the remaining content of the stream and deserialze it into the instance.</summary>
-        internal static Local.LocalFeatures Deserialize(Stream stream, Local.LocalFeatures instance)
+        internal static global::Local.LocalFeatures Deserialize(Stream stream, global::Local.LocalFeatures instance)
         {
             var br = new BinaryReader(stream);
-            instance.MyEnum = LocalFeatureTest.TopEnum.First;
+            instance.MyEnum = global::LocalFeatureTest.TopEnum.First;
             while (true)
             {
                 int keyByte = stream.ReadByte();
@@ -99,33 +99,33 @@ namespace Local
                         continue;
                     // Field 8 LengthDelimited
                     case 66:
-                        Mine.MyMessageV1.DeserializeLengthDelimited(stream, instance.TestingReadOnly);
+                        global::Mine.MyMessageV1.DeserializeLengthDelimited(stream, instance.TestingReadOnly);
                         continue;
                     // Field 9 LengthDelimited
                     case 74:
                         if (instance.MyInterface == null)
                             throw new InvalidOperationException("Can't deserialize into a interfaces null pointer");
                         else
-                            LocalFeatureTest.InterfaceTestSerializer.DeserializeLengthDelimited(stream, instance.MyInterface);
+                            global::LocalFeatureTest.InterfaceTestSerializer.DeserializeLengthDelimited(stream, instance.MyInterface);
                         continue;
                     // Field 10 LengthDelimited
                     case 82:
-                        LocalFeatureTest.StructTest.DeserializeLengthDelimited(stream, ref instance.MyStruct);
+                        global::LocalFeatureTest.StructTest.DeserializeLengthDelimited(stream, ref instance.MyStruct);
                         continue;
                     // Field 11 LengthDelimited
                     case 90:
-                        TestB.ExternalStructSerializer.DeserializeLengthDelimited(stream, ref instance.MyExtStruct);
+                        global::TestB.ExternalStructSerializer.DeserializeLengthDelimited(stream, ref instance.MyExtStruct);
                         continue;
                     // Field 12 LengthDelimited
                     case 98:
                         if (instance.MyExtClass == null)
-                            instance.MyExtClass = TestB.ExternalClassSerializer.DeserializeLengthDelimited(stream);
+                            instance.MyExtClass = global::TestB.ExternalClassSerializer.DeserializeLengthDelimited(stream);
                         else
-                            TestB.ExternalClassSerializer.DeserializeLengthDelimited(stream, instance.MyExtClass);
+                            global::TestB.ExternalClassSerializer.DeserializeLengthDelimited(stream, instance.MyExtClass);
                         continue;
                     // Field 13 Varint
                     case 104:
-                        instance.MyEnum = (LocalFeatureTest.TopEnum)global::SilentOrbit.ProtocolBuffers.ProtocolParser.ReadUInt64(stream);
+                        instance.MyEnum = (global::LocalFeatureTest.TopEnum)global::SilentOrbit.ProtocolBuffers.ProtocolParser.ReadUInt64(stream);
                         continue;
                 }
 
@@ -147,10 +147,10 @@ namespace Local
         }
 
         /// <summary>Read the VarInt length prefix and the given number of bytes from the stream and deserialze it into the instance.</summary>
-        internal static Local.LocalFeatures DeserializeLengthDelimited(Stream stream, Local.LocalFeatures instance)
+        internal static global::Local.LocalFeatures DeserializeLengthDelimited(Stream stream, global::Local.LocalFeatures instance)
         {
             var br = new BinaryReader(stream);
-            instance.MyEnum = LocalFeatureTest.TopEnum.First;
+            instance.MyEnum = global::LocalFeatureTest.TopEnum.First;
             long limit = global::SilentOrbit.ProtocolBuffers.ProtocolParser.ReadUInt32(stream);
             limit += stream.Position;
             while (true)
@@ -198,33 +198,33 @@ namespace Local
                         continue;
                     // Field 8 LengthDelimited
                     case 66:
-                        Mine.MyMessageV1.DeserializeLengthDelimited(stream, instance.TestingReadOnly);
+                        global::Mine.MyMessageV1.DeserializeLengthDelimited(stream, instance.TestingReadOnly);
                         continue;
                     // Field 9 LengthDelimited
                     case 74:
                         if (instance.MyInterface == null)
                             throw new InvalidOperationException("Can't deserialize into a interfaces null pointer");
                         else
-                            LocalFeatureTest.InterfaceTestSerializer.DeserializeLengthDelimited(stream, instance.MyInterface);
+                            global::LocalFeatureTest.InterfaceTestSerializer.DeserializeLengthDelimited(stream, instance.MyInterface);
                         continue;
                     // Field 10 LengthDelimited
                     case 82:
-                        LocalFeatureTest.StructTest.DeserializeLengthDelimited(stream, ref instance.MyStruct);
+                        global::LocalFeatureTest.StructTest.DeserializeLengthDelimited(stream, ref instance.MyStruct);
                         continue;
                     // Field 11 LengthDelimited
                     case 90:
-                        TestB.ExternalStructSerializer.DeserializeLengthDelimited(stream, ref instance.MyExtStruct);
+                        global::TestB.ExternalStructSerializer.DeserializeLengthDelimited(stream, ref instance.MyExtStruct);
                         continue;
                     // Field 12 LengthDelimited
                     case 98:
                         if (instance.MyExtClass == null)
-                            instance.MyExtClass = TestB.ExternalClassSerializer.DeserializeLengthDelimited(stream);
+                            instance.MyExtClass = global::TestB.ExternalClassSerializer.DeserializeLengthDelimited(stream);
                         else
-                            TestB.ExternalClassSerializer.DeserializeLengthDelimited(stream, instance.MyExtClass);
+                            global::TestB.ExternalClassSerializer.DeserializeLengthDelimited(stream, instance.MyExtClass);
                         continue;
                     // Field 13 Varint
                     case 104:
-                        instance.MyEnum = (LocalFeatureTest.TopEnum)global::SilentOrbit.ProtocolBuffers.ProtocolParser.ReadUInt64(stream);
+                        instance.MyEnum = (global::LocalFeatureTest.TopEnum)global::SilentOrbit.ProtocolBuffers.ProtocolParser.ReadUInt64(stream);
                         continue;
                 }
 
@@ -246,10 +246,10 @@ namespace Local
         }
 
         /// <summary>Read the given number of bytes from the stream and deserialze it into the instance.</summary>
-        internal static Local.LocalFeatures DeserializeLength(Stream stream, int length, Local.LocalFeatures instance)
+        internal static global::Local.LocalFeatures DeserializeLength(Stream stream, int length, global::Local.LocalFeatures instance)
         {
             var br = new BinaryReader(stream);
-            instance.MyEnum = LocalFeatureTest.TopEnum.First;
+            instance.MyEnum = global::LocalFeatureTest.TopEnum.First;
             long limit = stream.Position + length;
             while (true)
             {
@@ -296,33 +296,33 @@ namespace Local
                         continue;
                     // Field 8 LengthDelimited
                     case 66:
-                        Mine.MyMessageV1.DeserializeLengthDelimited(stream, instance.TestingReadOnly);
+                        global::Mine.MyMessageV1.DeserializeLengthDelimited(stream, instance.TestingReadOnly);
                         continue;
                     // Field 9 LengthDelimited
                     case 74:
                         if (instance.MyInterface == null)
                             throw new InvalidOperationException("Can't deserialize into a interfaces null pointer");
                         else
-                            LocalFeatureTest.InterfaceTestSerializer.DeserializeLengthDelimited(stream, instance.MyInterface);
+                            global::LocalFeatureTest.InterfaceTestSerializer.DeserializeLengthDelimited(stream, instance.MyInterface);
                         continue;
                     // Field 10 LengthDelimited
                     case 82:
-                        LocalFeatureTest.StructTest.DeserializeLengthDelimited(stream, ref instance.MyStruct);
+                        global::LocalFeatureTest.StructTest.DeserializeLengthDelimited(stream, ref instance.MyStruct);
                         continue;
                     // Field 11 LengthDelimited
                     case 90:
-                        TestB.ExternalStructSerializer.DeserializeLengthDelimited(stream, ref instance.MyExtStruct);
+                        global::TestB.ExternalStructSerializer.DeserializeLengthDelimited(stream, ref instance.MyExtStruct);
                         continue;
                     // Field 12 LengthDelimited
                     case 98:
                         if (instance.MyExtClass == null)
-                            instance.MyExtClass = TestB.ExternalClassSerializer.DeserializeLengthDelimited(stream);
+                            instance.MyExtClass = global::TestB.ExternalClassSerializer.DeserializeLengthDelimited(stream);
                         else
-                            TestB.ExternalClassSerializer.DeserializeLengthDelimited(stream, instance.MyExtClass);
+                            global::TestB.ExternalClassSerializer.DeserializeLengthDelimited(stream, instance.MyExtClass);
                         continue;
                     // Field 13 Varint
                     case 104:
-                        instance.MyEnum = (LocalFeatureTest.TopEnum)global::SilentOrbit.ProtocolBuffers.ProtocolParser.ReadUInt64(stream);
+                        instance.MyEnum = (global::LocalFeatureTest.TopEnum)global::SilentOrbit.ProtocolBuffers.ProtocolParser.ReadUInt64(stream);
                         continue;
                 }
 
@@ -388,7 +388,7 @@ namespace Local
                 // Key for field: 8, LengthDelimited
                 stream.WriteByte(66);
                 ﻿msField.SetLength(0);
-                Mine.MyMessageV1.Serialize(msField, instance.TestingReadOnly);
+                global::Mine.MyMessageV1.Serialize(msField, instance.TestingReadOnly);
                 // Length delimited byte array
                 uint length8 = (uint)msField.Length;
                 global::SilentOrbit.ProtocolBuffers.ProtocolParser.WriteUInt32(stream, length8);
@@ -400,7 +400,7 @@ namespace Local
             // Key for field: 9, LengthDelimited
             stream.WriteByte(74);
             ﻿msField.SetLength(0);
-            LocalFeatureTest.InterfaceTestSerializer.Serialize(msField, instance.MyInterface);
+            global::LocalFeatureTest.InterfaceTestSerializer.Serialize(msField, instance.MyInterface);
             // Length delimited byte array
             uint length9 = (uint)msField.Length;
             global::SilentOrbit.ProtocolBuffers.ProtocolParser.WriteUInt32(stream, length9);
@@ -409,7 +409,7 @@ namespace Local
             // Key for field: 10, LengthDelimited
             stream.WriteByte(82);
             ﻿msField.SetLength(0);
-            LocalFeatureTest.StructTest.Serialize(msField, instance.MyStruct);
+            global::LocalFeatureTest.StructTest.Serialize(msField, instance.MyStruct);
             // Length delimited byte array
             uint length10 = (uint)msField.Length;
             global::SilentOrbit.ProtocolBuffers.ProtocolParser.WriteUInt32(stream, length10);
@@ -418,7 +418,7 @@ namespace Local
             // Key for field: 11, LengthDelimited
             stream.WriteByte(90);
             ﻿msField.SetLength(0);
-            TestB.ExternalStructSerializer.Serialize(msField, instance.MyExtStruct);
+            global::TestB.ExternalStructSerializer.Serialize(msField, instance.MyExtStruct);
             // Length delimited byte array
             uint length11 = (uint)msField.Length;
             global::SilentOrbit.ProtocolBuffers.ProtocolParser.WriteUInt32(stream, length11);
@@ -429,7 +429,7 @@ namespace Local
                 // Key for field: 12, LengthDelimited
                 stream.WriteByte(98);
                 ﻿msField.SetLength(0);
-                TestB.ExternalClassSerializer.Serialize(msField, instance.MyExtClass);
+                global::TestB.ExternalClassSerializer.Serialize(msField, instance.MyExtClass);
                 // Length delimited byte array
                 uint length12 = (uint)msField.Length;
                 global::SilentOrbit.ProtocolBuffers.ProtocolParser.WriteUInt32(stream, length12);
@@ -466,7 +466,7 @@ namespace LocalFeatureTest
     public static class InterfaceTestSerializer
     {
         /// <summary>Helper: put the buffer into a MemoryStream before deserializing</summary>
-        public static LocalFeatureTest.InterfaceTest Deserialize(byte[] buffer, LocalFeatureTest.InterfaceTest instance)
+        public static global::LocalFeatureTest.InterfaceTest Deserialize(byte[] buffer, global::LocalFeatureTest.InterfaceTest instance)
         {
             using (var ms = new MemoryStream(buffer))
                 Deserialize(ms, instance);
@@ -474,7 +474,7 @@ namespace LocalFeatureTest
         }
 
         /// <summary>Takes the remaining content of the stream and deserialze it into the instance.</summary>
-        public static LocalFeatureTest.InterfaceTest Deserialize(Stream stream, LocalFeatureTest.InterfaceTest instance)
+        public static global::LocalFeatureTest.InterfaceTest Deserialize(Stream stream, global::LocalFeatureTest.InterfaceTest instance)
         {
             while (true)
             {
@@ -498,7 +498,7 @@ namespace LocalFeatureTest
         }
 
         /// <summary>Read the VarInt length prefix and the given number of bytes from the stream and deserialze it into the instance.</summary>
-        public static LocalFeatureTest.InterfaceTest DeserializeLengthDelimited(Stream stream, LocalFeatureTest.InterfaceTest instance)
+        public static global::LocalFeatureTest.InterfaceTest DeserializeLengthDelimited(Stream stream, global::LocalFeatureTest.InterfaceTest instance)
         {
             long limit = global::SilentOrbit.ProtocolBuffers.ProtocolParser.ReadUInt32(stream);
             limit += stream.Position;
@@ -531,7 +531,7 @@ namespace LocalFeatureTest
         }
 
         /// <summary>Read the given number of bytes from the stream and deserialze it into the instance.</summary>
-        public static LocalFeatureTest.InterfaceTest DeserializeLength(Stream stream, int length, LocalFeatureTest.InterfaceTest instance)
+        public static global::LocalFeatureTest.InterfaceTest DeserializeLength(Stream stream, int length, global::LocalFeatureTest.InterfaceTest instance)
         {
             long limit = stream.Position + length;
             while (true)
@@ -623,7 +623,7 @@ namespace LocalFeatureTest
         }
 
         /// <summary>Helper: put the buffer into a MemoryStream before deserializing</summary>
-        public static LocalFeatureTest.StructTest Deserialize(byte[] buffer, ref LocalFeatureTest.StructTest instance)
+        public static global::LocalFeatureTest.StructTest Deserialize(byte[] buffer, ref global::LocalFeatureTest.StructTest instance)
         {
             using (var ms = new MemoryStream(buffer))
                 Deserialize(ms, ref instance);
@@ -631,7 +631,7 @@ namespace LocalFeatureTest
         }
 
         /// <summary>Takes the remaining content of the stream and deserialze it into the instance.</summary>
-        public static LocalFeatureTest.StructTest Deserialize(Stream stream, ref LocalFeatureTest.StructTest instance)
+        public static global::LocalFeatureTest.StructTest Deserialize(Stream stream, ref global::LocalFeatureTest.StructTest instance)
         {
             while (true)
             {
@@ -655,7 +655,7 @@ namespace LocalFeatureTest
         }
 
         /// <summary>Read the VarInt length prefix and the given number of bytes from the stream and deserialze it into the instance.</summary>
-        public static LocalFeatureTest.StructTest DeserializeLengthDelimited(Stream stream, ref LocalFeatureTest.StructTest instance)
+        public static global::LocalFeatureTest.StructTest DeserializeLengthDelimited(Stream stream, ref global::LocalFeatureTest.StructTest instance)
         {
             long limit = global::SilentOrbit.ProtocolBuffers.ProtocolParser.ReadUInt32(stream);
             limit += stream.Position;
@@ -688,7 +688,7 @@ namespace LocalFeatureTest
         }
 
         /// <summary>Read the given number of bytes from the stream and deserialze it into the instance.</summary>
-        public static LocalFeatureTest.StructTest DeserializeLength(Stream stream, int length, ref LocalFeatureTest.StructTest instance)
+        public static global::LocalFeatureTest.StructTest DeserializeLength(Stream stream, int length, ref global::LocalFeatureTest.StructTest instance)
         {
             long limit = stream.Position + length;
             while (true)
@@ -783,7 +783,7 @@ namespace TestB
         }
 
         /// <summary>Helper: put the buffer into a MemoryStream before deserializing</summary>
-        public static TestB.ExternalStruct Deserialize(byte[] buffer, ref TestB.ExternalStruct instance)
+        public static global::TestB.ExternalStruct Deserialize(byte[] buffer, ref global::TestB.ExternalStruct instance)
         {
             using (var ms = new MemoryStream(buffer))
                 Deserialize(ms, ref instance);
@@ -791,7 +791,7 @@ namespace TestB
         }
 
         /// <summary>Takes the remaining content of the stream and deserialze it into the instance.</summary>
-        public static TestB.ExternalStruct Deserialize(Stream stream, ref TestB.ExternalStruct instance)
+        public static global::TestB.ExternalStruct Deserialize(Stream stream, ref global::TestB.ExternalStruct instance)
         {
             var br = new BinaryReader(stream);
             while (true)
@@ -825,7 +825,7 @@ namespace TestB
         }
 
         /// <summary>Read the VarInt length prefix and the given number of bytes from the stream and deserialze it into the instance.</summary>
-        public static TestB.ExternalStruct DeserializeLengthDelimited(Stream stream, ref TestB.ExternalStruct instance)
+        public static global::TestB.ExternalStruct DeserializeLengthDelimited(Stream stream, ref global::TestB.ExternalStruct instance)
         {
             var br = new BinaryReader(stream);
             long limit = global::SilentOrbit.ProtocolBuffers.ProtocolParser.ReadUInt32(stream);
@@ -868,7 +868,7 @@ namespace TestB
         }
 
         /// <summary>Read the given number of bytes from the stream and deserialze it into the instance.</summary>
-        public static TestB.ExternalStruct DeserializeLength(Stream stream, int length, ref TestB.ExternalStruct instance)
+        public static global::TestB.ExternalStruct DeserializeLength(Stream stream, int length, ref global::TestB.ExternalStruct instance)
         {
             var br = new BinaryReader(stream);
             long limit = stream.Position + length;
@@ -974,7 +974,7 @@ namespace TestB
         }
 
         /// <summary>Helper: put the buffer into a MemoryStream before deserializing</summary>
-        public static TestB.ExternalClass Deserialize(byte[] buffer, TestB.ExternalClass instance)
+        public static global::TestB.ExternalClass Deserialize(byte[] buffer, global::TestB.ExternalClass instance)
         {
             using (var ms = new MemoryStream(buffer))
                 Deserialize(ms, instance);
@@ -982,7 +982,7 @@ namespace TestB
         }
 
         /// <summary>Takes the remaining content of the stream and deserialze it into the instance.</summary>
-        public static TestB.ExternalClass Deserialize(Stream stream, TestB.ExternalClass instance)
+        public static global::TestB.ExternalClass Deserialize(Stream stream, global::TestB.ExternalClass instance)
         {
             while (true)
             {
@@ -1015,7 +1015,7 @@ namespace TestB
         }
 
         /// <summary>Read the VarInt length prefix and the given number of bytes from the stream and deserialze it into the instance.</summary>
-        public static TestB.ExternalClass DeserializeLengthDelimited(Stream stream, TestB.ExternalClass instance)
+        public static global::TestB.ExternalClass DeserializeLengthDelimited(Stream stream, global::TestB.ExternalClass instance)
         {
             long limit = global::SilentOrbit.ProtocolBuffers.ProtocolParser.ReadUInt32(stream);
             limit += stream.Position;
@@ -1057,7 +1057,7 @@ namespace TestB
         }
 
         /// <summary>Read the given number of bytes from the stream and deserialze it into the instance.</summary>
-        public static TestB.ExternalClass DeserializeLength(Stream stream, int length, TestB.ExternalClass instance)
+        public static global::TestB.ExternalClass DeserializeLength(Stream stream, int length, global::TestB.ExternalClass instance)
         {
             long limit = stream.Position + length;
             while (true)

--- a/TestProgram/Generated/GeneratedLocal.cs
+++ b/TestProgram/Generated/GeneratedLocal.cs
@@ -35,18 +35,18 @@ namespace Local
         public string PR { get; set; }
 
         /// <summary>Generate a c# readonly field</summary>
-        public readonly Mine.MyMessageV1 TestingReadOnly = new Mine.MyMessageV1();
+        public readonly global::Mine.MyMessageV1 TestingReadOnly = new global::Mine.MyMessageV1();
 
         /// <summary>When deserializing this one must be set to a class before</summary>
-        public LocalFeatureTest.InterfaceTest MyInterface { get; set; }
+        public global::LocalFeatureTest.InterfaceTest MyInterface { get; set; }
 
-        public LocalFeatureTest.StructTest MyStruct;
+        public global::LocalFeatureTest.StructTest MyStruct;
 
-        public TestB.ExternalStruct MyExtStruct;
+        public global::TestB.ExternalStruct MyExtStruct;
 
-        public TestB.ExternalClass MyExtClass { get; set; }
+        public global::TestB.ExternalClass MyExtClass { get; set; }
 
-        public LocalFeatureTest.TopEnum MyEnum { get; set; }
+        public global::LocalFeatureTest.TopEnum MyEnum { get; set; }
 
         // protected virtual void BeforeSerialize() {}
         // protected virtual void AfterDeserialize() {}
@@ -78,6 +78,7 @@ namespace TestB
 }
 namespace Mine
 {
+
 
 }
 namespace Yours
@@ -116,5 +117,15 @@ namespace LocalFeatureTest
 }
 namespace Proto.Test
 {
+
+    public static class TestRpcNames
+    {
+        public const string Method = "Test_Method";
+    }
+
+    public interface ITestSupporter
+    {
+        proto.test.MyMessage Method(proto.test.MyMessage request);
+    }
 
 }

--- a/TestProgram/Generated/ProtocolParser.cs
+++ b/TestProgram/Generated/ProtocolParser.cs
@@ -4,9 +4,9 @@ using System.IO;
 using System.Text;
 using System.Collections.Generic;
 
-// 
-//  Read/Write string and byte arrays 
-// 
+//
+//  Read/Write string and byte arrays
+//
 namespace SilentOrbit.ProtocolBuffers
 {
     public static partial class ProtocolParser
@@ -64,7 +64,6 @@ namespace SilentOrbit.ProtocolBuffers
             WriteUInt32(stream, (uint)val.Length);
             stream.Write(val, 0, val.Length);
         }
-
     }
 
     [Obsolete("Renamed to PositionStream")]
@@ -72,7 +71,6 @@ namespace SilentOrbit.ProtocolBuffers
     {
         public StreamRead(Stream baseStream) : base(baseStream)
         {
-
         }
     }
 
@@ -82,7 +80,7 @@ namespace SilentOrbit.ProtocolBuffers
     /// </summary>
     public class PositionStream : Stream
     {
-        Stream stream;
+        readonly Stream stream;
 
         /// <summary>
         /// Bytes read in the stream starting from the beginning.
@@ -205,7 +203,6 @@ namespace SilentOrbit.ProtocolBuffers
         }
     }
 }
-
 #endregion
 #region ProtocolParserExceptions
 //
@@ -224,13 +221,12 @@ namespace SilentOrbit.ProtocolBuffers
         }
     }
 }
-
 #endregion
 #region ProtocolParserFixed
 //
 //  This file contain references on how to write and read
 //  fixed integers and float/double.
-//  
+//
 
 namespace SilentOrbit.ProtocolBuffers
 {
@@ -309,7 +305,7 @@ namespace SilentOrbit.ProtocolBuffers
             writer.Write(val);
         }
 
-        #endregion
+        #endregion Fixed Int, Only for reference
 
         #region Fixed: float, double. Only for reference
 
@@ -349,10 +345,9 @@ namespace SilentOrbit.ProtocolBuffers
             writer.Write(val);
         }
 
-        #endregion
+        #endregion Fixed: float, double. Only for reference
     }
 }
-
 #endregion
 #region ProtocolParserKey
 //
@@ -412,7 +407,6 @@ namespace SilentOrbit.ProtocolBuffers
 
     public static partial class ProtocolParser
     {
-
         public static Key ReadKey(Stream stream)
         {
             uint n = ReadUInt32(stream);
@@ -453,7 +447,7 @@ namespace SilentOrbit.ProtocolBuffers
                     ProtocolParser.ReadSkipVarInt(stream);
                     return;
                 default:
-                    throw new NotImplementedException("Unknown wire type: " + key.WireType);
+                    throw new ProtocolBufferException("Unknown wire type: " + key.WireType);
             }
         }
 
@@ -498,19 +492,17 @@ namespace SilentOrbit.ProtocolBuffers
                 case Wire.Varint:
                     return ProtocolParser.ReadVarIntBytes(stream);
                 default:
-                    throw new NotImplementedException("Unknown wire type: " + key.WireType);
+                    throw new ProtocolBufferException("Unknown wire type: " + key.WireType);
             }
         }
-
     }
 }
-
 #endregion
 #region ProtocolParserMemory
 
-/// <summary>
-/// MemoryStream management
-/// </summary>
+//
+// MemoryStream management
+//
 namespace SilentOrbit.ProtocolBuffers
 {
     public interface MemoryStreamStack : IDisposable
@@ -525,7 +517,7 @@ namespace SilentOrbit.ProtocolBuffers
     /// </summary>
     public class ThreadSafeStack : MemoryStreamStack
     {
-        Stack<MemoryStream> stack = new Stack<MemoryStream>();
+        readonly Stack<MemoryStream> stack = new Stack<MemoryStream>();
 
         /// <summary>
         /// The returned stream is not reset.
@@ -566,7 +558,7 @@ namespace SilentOrbit.ProtocolBuffers
     /// </summary>
     public class ThreadUnsafeStack : MemoryStreamStack
     {
-        Stack<MemoryStream> stack = new Stack<MemoryStream>();
+        readonly Stack<MemoryStream> stack = new Stack<MemoryStream>();
 
         /// <summary>
         /// The returned stream is not reset.
@@ -625,14 +617,13 @@ namespace SilentOrbit.ProtocolBuffers
         public static MemoryStreamStack Stack = new AllocationStack();
     }
 }
-
 #endregion
 #region ProtocolParserMemory4
 
-/// <summary>
-/// MemoryStream management.
-/// .NET 4 features not added when the --net3 flag is being used
-/// </summary>
+//
+// MemoryStream management.
+// .NET 4 features not added when the --net3 flag is being used
+//
 namespace SilentOrbit.ProtocolBuffers
 {
     using System.Collections.Concurrent;
@@ -667,7 +658,6 @@ namespace SilentOrbit.ProtocolBuffers
         }
     }
 }
-
 #endregion
 #region ProtocolParserVarInt
 
@@ -714,22 +704,22 @@ namespace SilentOrbit.ProtocolBuffers
 
         #region VarInt: int32, uint32, sint32
 
-        [Obsolete("Use (int)ReadUInt64(stream); //yes 64")]
         /// <summary>
         /// Since the int32 format is inefficient for negative numbers we have avoided to implement it.
         /// The same functionality can be achieved using: (int)ReadUInt64(stream);
         /// </summary>
+        [Obsolete("Use (int)ReadUInt64(stream); //yes 64")]
         public static int ReadInt32(Stream stream)
         {
             return (int)ReadUInt64(stream);
         }
 
-        [Obsolete("Use WriteUInt64(stream, (ulong)val); //yes 64, negative numbers are encoded that way")]
         /// <summary>
         /// Since the int32 format is inefficient for negative numbers we have avoided to imlplement.
         /// The same functionality can be achieved using: WriteUInt64(stream, (uint)val);
         /// Note that 64 must always be used for int32 to generate the ten byte wire format.
         /// </summary>
+        [Obsolete("Use WriteUInt64(stream, (ulong)val); //yes 64, negative numbers are encoded that way")]
         public static void WriteInt32(Stream stream, int val)
         {
             //signed varint is always encoded as 64 but values!
@@ -759,12 +749,11 @@ namespace SilentOrbit.ProtocolBuffers
         /// </summary>
         public static uint ReadUInt32(Stream stream)
         {
-            int b;
             uint val = 0;
 
             for (int n = 0; n < 5; n++)
             {
-                b = stream.ReadByte();
+                int b = stream.ReadByte();
                 if (b < 0)
                     throw new IOException("Stream ended too early");
 
@@ -787,10 +776,9 @@ namespace SilentOrbit.ProtocolBuffers
         /// </summary>
         public static void WriteUInt32(Stream stream, uint val)
         {
-            byte b;
             while (true)
             {
-                b = (byte)(val & 0x7F);
+                byte b = (byte)(val & 0x7F);
                 val = val >> 7;
                 if (val == 0)
                 {
@@ -805,25 +793,25 @@ namespace SilentOrbit.ProtocolBuffers
             }
         }
 
-        #endregion
+        #endregion VarInt: int32, uint32, sint32
 
         #region VarInt: int64, UInt64, SInt64
 
-        [Obsolete("Use (long)ReadUInt64(stream); instead")]
         /// <summary>
         /// Since the int64 format is inefficient for negative numbers we have avoided to implement it.
         /// The same functionality can be achieved using: (long)ReadUInt64(stream);
         /// </summary>
+        [Obsolete("Use (long)ReadUInt64(stream); instead")]
         public static int ReadInt64(Stream stream)
         {
             return (int)ReadUInt64(stream);
         }
 
-        [Obsolete("Use WriteUInt64 (stream, (ulong)val); instead")]
         /// <summary>
         /// Since the int64 format is inefficient for negative numbers we have avoided to implement.
         /// The same functionality can be achieved using: WriteUInt64 (stream, (ulong)val);
         /// </summary>
+        [Obsolete("Use WriteUInt64 (stream, (ulong)val); instead")]
         public static void WriteInt64(Stream stream, int val)
         {
             WriteUInt64(stream, (ulong)val);
@@ -851,12 +839,11 @@ namespace SilentOrbit.ProtocolBuffers
         /// </summary>
         public static ulong ReadUInt64(Stream stream)
         {
-            int b;
             ulong val = 0;
 
             for (int n = 0; n < 10; n++)
             {
-                b = stream.ReadByte();
+                int b = stream.ReadByte();
                 if (b < 0)
                     throw new IOException("Stream ended too early");
 
@@ -879,10 +866,9 @@ namespace SilentOrbit.ProtocolBuffers
         /// </summary>
         public static void WriteUInt64(Stream stream, ulong val)
         {
-            byte b;
             while (true)
             {
-                b = (byte)(val & 0x7F);
+                byte b = (byte)(val & 0x7F);
                 val = val >> 7;
                 if (val == 0)
                 {
@@ -897,7 +883,7 @@ namespace SilentOrbit.ProtocolBuffers
             }
         }
 
-        #endregion
+        #endregion VarInt: int64, UInt64, SInt64
 
         #region Varint: bool
 
@@ -918,7 +904,7 @@ namespace SilentOrbit.ProtocolBuffers
             stream.WriteByte(val ? (byte)1 : (byte)0);
         }
 
-        #endregion
+        #endregion Varint: bool
     }
 }
 #endregion

--- a/TestProgram/ProtoSpec/LocalFeatures.proto
+++ b/TestProgram/ProtoSpec/LocalFeatures.proto
@@ -26,15 +26,15 @@ message local_features
     //Make class field of type TimeSpan, serialized to Ticks
     //:codetype = TimeSpan
     required int64 Uptime = 1;
-    
+
     //Make class field of type DateTime, serialized to Ticks
     //:codetype = DateTime
     required int64 DueDate = 2;
-    
+
     //Do not generate class field, must be implemented in other partial class
     //:external
     required double Amount = 3;
-    
+
     //Custom field access types. Default: public
     //:access = private //public, internal, protected or private
     optional string Denial = 4;
@@ -42,19 +42,19 @@ message local_features
     optional string Secret = 5;
     //:access = internal    //public, internal, protected or private
     optional string Internal = 6;
-    
+
     optional string PR = 7;
-    
+
     //Generate a c# readonly field
     //:readonly
     optional proto.test.my_message_v1 testing_read_only = 8;
-    
+
     //When deserializing this one must be set to a class before
     required interface_test MyInterface = 9;
     optional struct_test MyStruct = 10;
     optional external_struct MyExtStruct = 11;
     optional external_class MyExtClass = 12;
-    
+
     optional top_enum MyEnum = 13;
 }
 

--- a/TestProgram/ProtoSpec/ProtoFeatures.proto
+++ b/TestProgram/ProtoSpec/ProtoFeatures.proto
@@ -48,7 +48,7 @@ message my_message_v2
         ETest2 = 3;
         ETest3 = 2;
     }
-    
+
     enum aliased_enum
     {
         option allow_alias = true;
@@ -61,15 +61,15 @@ message my_message_v2
 
     required my_enum field_q = 17;
     optional my_enum field_r = 18 [default = ETest2];
-    
+
     //:access = protected  //public, internal, protected or private
     optional string dummy = 19 [deprecated=true];
-    
+
     repeated fixed32 field_t = 20 [packed=true];
     repeated uint32 field_s = 21;
-    
+
     optional their_message field_u = 22;
-    
+
     repeated their_message field_v = 23;
 
     optional int32 nullable_int = 24;
@@ -103,7 +103,7 @@ message Container {
     }
 
     optional Nested myNestedMessage = 1;
-    
+
     //Name collision test
     optional Nested Nested = 2;
 }
@@ -147,4 +147,9 @@ enum MyEnum {
 
   FOO = 1 [(my_enum_value_option) = 321];
   BAR = 2;
+}
+
+service TestService
+{
+    rpc method(MyMessage) returns(MyMessage);
 }


### PR DESCRIPTION
While google's https://github.com/protocolbuffers/protobuf supports C# code generation now, I found it fun and easy to use and extend yours.

In this PR I suggest code generation for `service` syntaxis (which google's [doesn't support completely](https://developers.google.com/protocol-buffers/docs/reference/csharp-generated#service)) when passing `--generate-services` option.

For each service there will be two generated types (`Service` will be replaced with actual service name):
- IServiceSupporter interface that must be implemented by app that will receive RPC requests
- ServiceRpcNames static class that holds constants with RPC method names.

Also, even without `--generate-services` option, request and response types existance will be checked.

Note that there is no actual RPC implementation. These types only allow to reduce boilerplate code and yet keep RPC protocol consistent with single `service` definition instead of separate request/response types definitions.